### PR TITLE
Adding three more commonwealth of VA orgs

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -706,7 +706,10 @@ U.S. States:
   - twdb
   - TxDOT
   - UtahForestryFireStateLands
+  - LibraryofVA
+  - VDEQ
   - VDGIF
+  - Virginia-Department-of-Health
   - Virginia-House-of-Delegates
   - vtrans
   - vtrans-rail


### PR DESCRIPTION
In preparation for a presentation to representatives from the Commonwealth of Virginia (a :us: state), I found some additional GitHub Organizations that were not listed in the directory.

Adding them here, including:
- VA Dept of Health
- Library of Virginia
- VA dept of Environmental Quality